### PR TITLE
Support fallback between realys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /server/src/github.com/ethereum/go-ethereum/
 /metacoin/
 tabookey-gasless-0.1.0.tgz
+/.vscode/settings.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+    // To debug truffle tests, first run this in project folder
+    // npm install truffle-core
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // Note: For macOS 10.14.1 Mojave update the command line tools from the Apple developer website.
+            // https://github.com/derekparker/delve/issues/1398#issuecomment-435613739
+            // Also, add this to 'settings.js': 
+            // "go.inferGopath": false,
+            // "go.gopath": "${workspaceFolder}/build/server/:/Users/alexf/go/"
+            "name": "Go Server",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/server/src/RelayHttpServer.go"
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Truffle Test",
+            "cwd": "${workspaceFolder}",
+            "program": "${workspaceFolder}/node_modules/truffle-core/cli.js",
+            "args": [
+                "test"
+            ]
+        }
+    ]
+}

--- a/src/js/relayclient/HttpWrapper.js
+++ b/src/js/relayclient/HttpWrapper.js
@@ -1,0 +1,30 @@
+var logreq = false
+var unique_id = 1
+
+class HttpWrapper {
+
+    constructor(web3) {
+        this.web3 = web3
+    }
+
+    send(url, jsonRequestData, callback) {
+
+        let localid = unique_id++
+        if (logreq) {
+            console.log("sending request:", localid, url, JSON.stringify(jsonRequestData).slice(0, 40))
+        }
+
+        let callback1 = function (e, r) {
+            if (e && ("" + e).indexOf("Invalid JSON RPC response") >= 0) {
+                e = { error: "invalid-json" }
+            }
+            if (logreq) {
+                console.log("got response:", localid, JSON.stringify(r).slice(0, 40), "err=", JSON.stringify(e).slice(0, 40))
+            }
+            callback(e, r)
+        }
+        new this.web3.providers.HttpProvider(url).sendAsync(jsonRequestData, callback1);
+    }
+}
+
+module.exports = HttpWrapper

--- a/src/js/relayclient/ServerHelper.js
+++ b/src/js/relayclient/ServerHelper.js
@@ -1,0 +1,168 @@
+
+
+const addPastEvents = require('./addPastEvents')
+
+class ActiveRelayPinger {
+
+    // TODO: 'httpSend' should be on a network layer
+    constructor(filteredRelays, httpSend) {
+        this.filteredRelays = filteredRelays
+        this.remainingRelays = filteredRelays
+        this.httpSend = httpSend
+        this.pingedRelays = 0
+        this.relaysCount = filteredRelays.size
+    }
+
+    /**
+     * Ping those relays that were not returned yet. Remove the retuned relay (first to respond) from {@link remainingRelays}
+     * @returns the first relay to respond to a ping message. Note: will never return the same relay twice.
+     */
+    async nextRelay() {
+        if (this.filteredRelays.length === 0 || this.remainingRelays.length === 0) {
+            return null
+        }
+
+        let firstRelayToRespond = await this.raceToSuccess(
+            this.filteredRelays.map(relay => this.getRelayAddressPing(relay.relayUrl))
+        );
+        this.remainingRelays = this.remainingRelays.filter(a => a.relayUrl !== firstRelayToRespond.relayUrl)
+        this.pingedRelays++
+        return firstRelayToRespond
+    }
+
+    /**
+     * @returns JSON response from the relay server, but adds the requested URL to it:
+     * { relayUrl: url,
+     *   RelayServerAddress: address
+     * }
+     */
+    async getRelayAddressPing(relayUrl) {
+        let self = this
+        return new Promise(function (resolve, reject) {
+            let callback = function (error, body) {
+                if (error) {
+                    reject(error);
+                    return
+                }
+                try {
+                    body.relayUrl = relayUrl
+                    resolve(body);
+                }
+                catch (err) {
+                    reject(err);
+                }
+            }
+            self.httpSend.send(relayUrl + "/getaddr", {}, callback)
+        });
+    }
+
+    /**
+     * From https://stackoverflow.com/a/37235207 (modified to catch exceptions)
+     * Resolves once any promise resolves, ignores the rest, ignores rejections
+     */
+    async raceToSuccess(promises) {
+        let numRejected = 0;
+        return new Promise(
+            (resolve, reject) =>
+                promises.forEach(
+                    promise =>
+                        promise.then((res) =>
+                            resolve(res)
+                        )
+                            .catch(err => {
+                                // console.log(err)
+                                if (++numRejected === promises.length) {
+                                    reject("No response from any server.", err);
+                                }
+                            })
+                )
+        );
+    }
+}
+
+class ServerHelper {
+    /**
+     * 
+     * @param {*} minStake 
+     * @param {*} minDelay 
+     * @param {*} httpSend 
+     */
+    constructor(minStake, minDelay, httpSend) {
+        this.minStake = minStake
+        this.minDelay = minDelay
+        this.httpSend = httpSend
+
+        this.filteredRelays = []
+        this.isInitialized = false
+    }
+    /**
+     * @param {*} relayHub 
+     * @param {*} relayHubAddress 
+     */
+    setHub(relayHub) {
+        //todo: re-run only on hub
+        this.relayHub = relayHub
+        addPastEvents(this.relayHub)
+        this.relayHubAddress = this.relayHub.address
+    }
+
+    async newActiveRelayPinger() {
+        if (this.relayHub === 'undefined') {
+            throw new Error("Must call to setHub first!")
+        }
+        if (this.filteredRelays.length == 0)
+        {
+            await this.fetchRelaysAdded()
+        }
+        return new ActiveRelayPinger(this.filteredRelays, this.httpSend)
+    }
+
+    /**
+     * Iterates through all RelayAdded and RelayRemoved logs emitted by given hub
+     * initializes an array {@link filteredRelays} of relays curently registered on given RelayHub contract
+     */
+    async fetchRelaysAdded() {
+        let activeRelays = {}
+        let addedAndRemovedEvents = await this.relayHub.getPastEvents({ address: this.relayHub.address, fromBlock: 1, topics: [["RelayAdded", "RelayRemoved"]] })
+
+        for (var index in addedAndRemovedEvents) {
+            let event = addedAndRemovedEvents[index]
+            if (event.event === "RelayAdded") {
+                activeRelays[event.args.relay] = {
+                    relayUrl: event.args.url,
+                    transactionFee: event.args.transactionFee,
+                    stake: event.args.stake,
+                    unstakeDelay: event.args.unstakeDelay
+                }
+            } else if (event.event === "RelayRemoved") {
+                delete activeRelays[event.args.relay]
+            }
+        }
+
+        let filteredRelays = Object.values(activeRelays)
+
+        let origRelays = filteredRelays
+        if (this.minStake) {
+            filteredRelays = filteredRelays.filter(a => a.stake >= this.minStake)
+        }
+
+        if (this.minDelay) {
+            filteredRelays = filteredRelays.filter(a => a.unstakeDelay >= this.minDelay)
+        }
+
+        let size = filteredRelays.length
+
+        if (size == 0) {
+            throw new Error("no valid relays. orig relays=" + JSON.stringify(origRelays))
+        }
+
+        filteredRelays = filteredRelays.sort((a, b) => {
+            return a.txFee - b.txFee
+        }).slice(0, size)
+
+        this.filteredRelays = filteredRelays
+        this.isInitialized = true
+    }
+}
+
+module.exports = ServerHelper

--- a/src/js/relayclient/relayclient.js
+++ b/src/js/relayclient/relayclient.js
@@ -4,13 +4,14 @@ const getTransactionSignature = utils.getTransactionSignature;
 const removeHexPrefix = utils.removeHexPrefix;
 const padTo64 = utils.padTo64;
 
+const ServerHelper = require('./ServerHelper');
+const HttpWrapper = require('./HttpWrapper');
 const ethUtils = require('ethereumjs-util');
 const ethJsTx = require('ethereumjs-tx');
 const abi_decoder = require('abi-decoder');
 
 const relayHubAbi = require('./RelayHubApi')
 const relayRecipientAbi = require('./RelayRecipientApi')
-const addPastEvents = require('./addPastEvents')
 
 const {promisify} = require("es6-promisify");
 //const {promisify} = require("promisify");
@@ -37,11 +38,13 @@ function RelayClient(web3, config) {
     // TODO: require sign() or privKey
     this.config = config || {}
     this.web3 = web3
+    this.httpSend = new HttpWrapper(this.web3)
+    this.serverHelper = this.config.serverHelper || new ServerHelper(this.config.minStake || 0, this.config.minDelay || 0, this.httpSend)
 
     this.RelayRecipient = web3.eth.contract(relayRecipientAbi)
     this.RelayHub = web3.eth.contract(relayHubAbi)
+    this.serverHelper.setHub(this.RelayHub)
     //add missing "getPastEvents" in web3 v0.2..
-    addPastEvents(this.RelayHub)
 }
 
 /**
@@ -98,99 +101,6 @@ RelayClient.prototype.validateRelayResponse = function (returned_tx, address_rel
     }
 }
 
-/**
- * @returns on object containing the first relay to respond to a ping message,
- * as well as two other relays selected by fee, stake and delay.
- */
-RelayClient.prototype.findRelay = async function (relayHubAddress, minStake, minDelay, backups) {
-    let filteredRelays = await this.getRelaysAdded(relayHubAddress);
-
-    let origRelays = filteredRelays
-    if (minStake) {
-        filteredRelays = filteredRelays.filter(a => a.stake >= minStake)
-    }
-
-    if (minDelay) {
-        filteredRelays = filteredRelays.filter(a => a.unstakeDelay >= minDelay)
-    }
-
-    if (!backups) {
-        backups = 3
-    }
-
-    let size = filteredRelays.length > backups ? backups : filteredRelays.length
-
-    if (size == 0) {
-        throw new Error("no valid relays. orig relays=" + JSON.stringify(origRelays))
-    }
-
-    filteredRelays = filteredRelays.sort((a, b) => {
-        return a.txFee - b.txFee
-    }).slice(0, size)
-
-    let firstRelayToRespond = await this.raceToSuccess(
-        filteredRelays.map(relay => this.getRelayAddress(relay.relayUrl))
-    );
-
-    let lookupResult = {
-        firstRelayToRespond: firstRelayToRespond,
-        otherRelays: filteredRelays.filter(a => a.relayUrl !== firstRelayToRespond.relayUrl)
-    }
-
-    return lookupResult
-}
-
-/**
- * Iterates through all RelayAdded and RelayRemoved logs emitted by given hub
- * @param {*} relayHubAddress
- * @returns an array of relays cuurently registered on given RelayHub contract
- */
-RelayClient.prototype.getRelaysAdded = async function (relayHubAddress) {
-    let activeRelays = {}
-    let addedAndRemovedEvents = await this.RelayHub.getPastEvents({
-        address: relayHubAddress,
-        fromBlock: 1,
-        topics: [["RelayAdded", "RelayRemoved"]]
-    })
-
-    for (var index in addedAndRemovedEvents) {
-        let event = addedAndRemovedEvents[index]
-        if (event.event === "RelayAdded") {
-            activeRelays[event.args.relay] = {
-                relayUrl: event.args.url,
-                transactionFee: event.args.transactionFee,
-                stake: event.args.stake,
-                unstakeDelay: event.args.unstakeDelay
-            }
-        } else if (event.event === "RelayRemoved") {
-            delete activeRelays[event.args.relay]
-        }
-    }
-    return Object.values(activeRelays)
-}
-/**
- * From https://stackoverflow.com/a/37235207 (modified to catch exceptions)
- * Resolves once any promise resolves, ignores the rest, ignores rejections
- */
-RelayClient.prototype.raceToSuccess = function (promises) {
-    let numRejected = 0;
-    return new Promise(
-        (resolve, reject) =>
-            promises.forEach(
-                promise =>
-                    promise.then((res) =>
-                        resolve(res)
-                    )
-                        .catch(err => {
-                            // console.log(err)
-                            if (++numRejected === promises.length) {
-                                reject("No response from any server.", err);
-                            }
-                        })
-            )
-    );
-}
-
 function parseHexString(str) {
     var result = [];
     while (str.length >= 2) {
@@ -207,72 +117,57 @@ function parseHexString(str) {
  * @returns a Promise that resolves to an instance of {@link EthereumTx} signed by a relay
  */
 RelayClient.prototype.sendViaRelay = function (relayUrl, signature, from, to, encodedFunction, gasprice, gaslimit, relayFee, nonce, relayHubAddress, relayAddress) {
-    var self = this
 
-    return new Promise(function (resolve, reject) {
+  var self = this
 
-        let jsonRequestData = {
-            "encodedFunction": encodedFunction,
-            "signature": parseHexString(signature.replace(/^0x/, '')),
-            "from": from,
-            "to": to,
-            "gasPrice": gasprice,
-            "gasLimit": gaslimit,
-            "relayFee": relayFee,
-            "RecipientNonce": nonce,
-            "RelayHubAddress": relayHubAddress
-        };
+  return new Promise(function (resolve, reject) {
 
-        let callback = async function (error, body) {
-            if (error) {
-                reject(error);
-                return
-            }
+    let jsonRequestData = {
+      "encodedFunction": encodedFunction,
+      "signature": parseHexString(signature.replace(/^0x/, '')),
+      "from": from,
+      "to": to,
+      "gasPrice": gasprice,
+      "gasLimit": gaslimit,
+      "relayFee": relayFee,
+      "RecipientNonce": nonce,
+      "RelayHubAddress": relayHubAddress
+    };
 
-            if (!body) {
-                reject("Empty body received from server.");
-                return
-            }
+    let callback = async function (error, body) {
+      if (error) {
+        reject(error);
+        return
+      }
 
-            let validTransaction = self.validateRelayResponse(
-                body, relayAddress, from, to, encodedFunction,
-                relayFee, gasprice, gaslimit, nonce, relayHubAddress, relayAddress, signature);
+      if (!body) {
+        reject("Empty body received from server.");
+        return
+      }
 
-            if (validTransaction === undefined) {
-                reject("Failed to validate response")
-                return
-            }
+      let validTransaction
+      try {
+        validTransaction = self.validateRelayResponse(
+          body, relayAddress, from, to, encodedFunction,
+          relayFee, gasprice, gaslimit, nonce, relayHubAddress, relayAddress, signature);
+      }
+      catch (error) {
+        console.log(error)
+      }
 
-            var raw_tx = '0x' + validTransaction.serialize().toString('hex');
-            let txHash = "0x" + validTransaction.hash(false).toString('hex')
-            console.log("txHash= " + txHash);
-            self.broadcastRawTx(raw_tx, txHash);
-            resolve(validTransaction);
-        }
-        self.httpSend(relayUrl + "/relay", jsonRequestData, callback)
-    });
-}
+      if (validTransaction === undefined) {
+        reject("Failed to validate response")
+        return
+      }
 
-var logreq = false
-var unique_id = 1
-
-RelayClient.prototype.httpSend = function (url, jsonRequestData, callback) {
-
-    let localid = unique_id++
-    if (logreq) {
-        console.log("sending request:", localid, url, JSON.stringify(jsonRequestData).slice(0, 40))
+      var raw_tx = '0x' + validTransaction.serialize().toString('hex');
+      let txHash = "0x" + validTransaction.hash(false).toString('hex')
+      console.log("txHash= " + txHash);
+      self.broadcastRawTx(raw_tx, txHash);
+      resolve(validTransaction);
     }
-
-    let callback1 = function (e, r) {
-        if (e && ("" + e).indexOf("Invalid JSON RPC response") >= 0) {
-            e = {error: "invalid-json"}
-        }
-        if (logreq) {
-            console.log("got response:", localid, JSON.stringify(r).slice(0, 40), "err=", JSON.stringify(e).slice(0, 40))
-        }
-        callback(e, r)
-    }
-    new this.web3.providers.HttpProvider(url).sendAsync(jsonRequestData, callback1);
+    self.httpSend.send(relayUrl + "/relay", jsonRequestData, callback)
+  });
 }
 
 /**
@@ -325,47 +220,46 @@ RelayClient.prototype.balanceOf = async function (target) {
  * return value is the same as from sendTransaction
  */
 RelayClient.prototype.relayTransaction = async function (encodedFunctionCall, options) {
-    let relayRecipient = this.RelayRecipient.at(options.to)
 
-    let relayHubAddress = await promisify(relayRecipient.get_relay_hub.call)()
+  var self = this
+  let relayRecipient = this.RelayRecipient.at(options.to)
 
-    let relayUrl = this.config.relayUrl;
-    let relayAddress = this.config.relayAddress;
+  let relayHubAddress = await promisify(relayRecipient.get_relay_hub.call)()
 
-    if (!relayUrl || !relayAddress) {
+  let relayHub = this.RelayHub.at(relayHubAddress)
 
-        let res = await this.findRelay(relayHubAddress, this.config.minStake, this.config.minDelay, this.config.backups)
+  var nonce = (await promisify(relayHub.get_nonce.call)(options.from)).toNumber()
 
-        let r = res.firstRelayToRespond
-        relayUrl = r.relayUrl
-        relayAddress = r.RelayServerAddress
+  let pinger = await this.serverHelper.newActiveRelayPinger()
+  for (;;) {
+    let activeRelay = await pinger.nextRelay()    
+    if (activeRelay === null) {
+        throw new Error("No relay responded! " + pinger.relaysCount + " attempted, " + pinger.pingedRelays + " pinged")
     }
-
-    let relayHub = this.RelayHub.at(relayHubAddress)
-
-    var nonce = (await promisify(relayHub.get_nonce.call)(options.from)).toNumber()
+    let relayAddress = activeRelay.RelayServerAddress
+    let relayUrl = activeRelay.relayUrl
 
     let hash =
-        utils.getTransactionHash(
-            options.from,
-            options.to,
-            encodedFunctionCall,
-            options.txfee,
-            options.gas_price,
-            options.gas_limit,
-            nonce,
-            relayHub.address,
-            relayAddress);
+      utils.getTransactionHash(
+        options.from,
+        options.to,
+        encodedFunctionCall,
+        options.txfee,
+        options.gas_price,
+        options.gas_limit,
+        nonce,
+        relayHub.address,
+        relayAddress);
 
     let signature
-    if (typeof this.config.signForAccount === "function") {
-        console.log("=== using signForAccount")
-        signature = this.config.signForAccount(options.from, hash);
+    if (typeof self.config.signForAccount === "function") {
+      console.log("=== using signForAccount")
+      signature = self.config.signForAccount(options.from, hash);
     } else {
-        signature = await getTransactionSignature(options.from, hash);
+      signature = await getTransactionSignature(options.from, hash);
     }
-
-    return this.sendViaRelay(
+    try {
+      let validTransaction = await self.sendViaRelay(
         relayUrl,
         signature,
         options.from,
@@ -377,7 +271,13 @@ RelayClient.prototype.relayTransaction = async function (encodedFunctionCall, op
         nonce,
         relayHub.address,
         relayAddress
-    )
+      )
+      return validTransaction
+    }
+    catch (error) {
+      console.log("relayTransaction", error)
+    }
+  }
 }
 
 /**
@@ -427,43 +327,19 @@ RelayClient.prototype.runRelay = function (payload, callback) {
 }
 
 
-/**
- //returns struct from the relay server, and adds the URL to it:
- // { relayUrl: url,
-//   RelayServerAddress: address
-// }
- */
-RelayClient.prototype.getRelayAddress = function (relayUrl) {
-    let self = this
-    return new Promise(function (resolve, reject) {
-        let callback = function (error, body) {
-            if (error) {
-                reject(error);
-                return
-            }
-            try {
-                body.relayUrl = relayUrl
-                resolve(body);
-            } catch (err) {
-                reject(err);
-            }
-        }
-        self.httpSend(relayUrl + "/getaddr", {}, callback)
-    });
-}
 
-RelayClient.prototype.postAuditTransaction = function (signedTx, relayUrl) {
-    let self = this
-    return new Promise(function (resolve, reject) {
-        let callback = function (error, response) {
-            if (error) {
-                reject(error);
-                return
-            }
-            resolve(response);
-        }
-        self.httpSend(relayUrl + "/audit", {signedTx: signedTx}, callback);
-    });
+RelayClient.prototype.postAuditTransaction = function(signedTx, relayUrl) {
+  var self = this
+  return new Promise(function (resolve, reject) {
+    let callback = function (error, response) {
+      if (error) {
+        reject(error);
+        return
+      }
+      resolve(response);
+    }
+    self.httpSend.send(relayUrl + "/audit", { signedTx: signedTx }, callback);
+  });
 }
 
 /**

--- a/test/clientlib.js
+++ b/test/clientlib.js
@@ -22,7 +22,7 @@ contract('RelayClient', function (accounts) {
         rhub = await RelayHub.deployed()
         sr = await SampleRecipient.deployed()
         let deposit = 100000000000;
-        await sr.deposit({value: deposit});
+        await sr.deposit({ value: deposit });
         let known_deposit = await rhub.balances(sr.address);
         assert.equal(deposit, known_deposit);
         gasLess = await web3.personal.newAccount("password")
@@ -35,7 +35,7 @@ contract('RelayClient', function (accounts) {
         let b1 = await relayclient.balanceOf(sr.address)
         console.log("balance before redeposit" + b1.toNumber())
         let added = 200000
-        await sr.deposit({value: added});
+        await sr.deposit({ value: added });
         let b2 = await relayclient.balanceOf(sr.address)
         console.log("balance after redeposit" + b2.toNumber())
         assert.equal(b2 - b1, added)
@@ -51,7 +51,7 @@ contract('RelayClient', function (accounts) {
                 }
                 resolve(response);
             }
-            new web3.providers.HttpProvider(relayUrl + "/setRelayHub").sendAsync({relayHubAddress: relayHubAddress}, callback);
+            new web3.providers.HttpProvider(relayUrl + "/setRelayHub").sendAsync({ relayHubAddress: relayHubAddress }, callback);
         });
     }
 
@@ -61,8 +61,9 @@ contract('RelayClient', function (accounts) {
     });
 
     it("should get Relay Server's signing address from server", async function () {
-        let tbk = new RelayClient(web3, {relayUrl: localhostOne});
-        let res = await tbk.getRelayAddress(localhostOne);
+        let tbk = new RelayClient(web3, { relayUrl: localhostOne });
+        let pinger = await tbk.serverHelper.newActiveRelayPinger()
+        let res = await pinger.getRelayAddressPing(localhostOne);
         assert.equal("0x610bb1573d1046fcb8a70bbbd395754cd57c2b60", res.RelayServerAddress)
     });
 
@@ -79,19 +80,19 @@ contract('RelayClient', function (accounts) {
         // Added, removed, added again - go figure.
         // 2 x will not ping
         await register_new_relay(rhub, 1000, 20, 15, "https://abcd.com", accounts[4]);
-        await rhub.remove_relay_by_owner(accounts[4], {from: accounts[4]});
+        await rhub.remove_relay_by_owner(accounts[4], { from: accounts[4] });
         await register_new_relay(rhub, 1000, 20, 15, "https://abcd.com", accounts[4]);
 
         await register_new_relay(rhub, 1000, 20, 30, "https://abcd.com", accounts[5]);
 
-        await rhub.remove_relay_by_owner(accounts[2], {from: accounts[2]});
-        let tbk = new RelayClient(web3);
+        await rhub.remove_relay_by_owner(accounts[2], { from: accounts[2] });
         let minStake = 1000
         let minDelay = 10
-        let relay = await tbk.findRelay(rhub.address, minStake, minDelay);
-        assert.equal(relayAddress, relay.firstRelayToRespond.RelayServerAddress);
-        assert.equal(localhostOne, relay.firstRelayToRespond.relayUrl);
-        assert.equal(2, relay.otherRelays.length);
+        let tbk = new RelayClient(web3, { minStake: minStake, minDelay: minDelay });
+        let pinger = await tbk.serverHelper.newActiveRelayPinger()
+        let relay = await pinger.nextRelay()
+        assert.equal(relayAddress, relay.RelayServerAddress);
+        assert.equal(localhostOne, relay.relayUrl);
     });
 
     it("should use relay provided in constructor");
@@ -145,13 +146,13 @@ contract('RelayClient', function (accounts) {
 
         relayclient.hook(SampleRecipient)
 
-        let res = await sr.emitMessage("hello world", {from: gasLess})
+        let res = await sr.emitMessage("hello world", { from: gasLess })
 
         assert.equal(res.logs[0].event, "SampleRecipientEmitted")
         assert.equal(res.logs[0].args.message, "hello world")
         assert.equal(res.logs[0].args.real_sender, gasLess)
         assert.equal(res.logs[0].args.msg_sender.toLowerCase(), rhub.address.toLowerCase())
-        res = await sr.emitMessage("hello again", {from: accounts[3]})
+        res = await sr.emitMessage("hello again", { from: accounts[3] })
         assert.equal(res.logs[0].event, "SampleRecipientEmitted")
         assert.equal(res.logs[0].args.message, "hello again")
 
@@ -195,7 +196,7 @@ contract('RelayClient', function (accounts) {
         let reused_nonce = web3.eth.getTransactionCount(perpetrator_relay)
 
         // Make sure the transaction with that nonce was mined
-        let result = await sr.emitMessage("hello world", {from: perpetrator_relay})
+        let result = await sr.emitMessage("hello world", { from: perpetrator_relay })
         var log = result.logs[0];
         assert.equal("SampleRecipientEmitted", log.event);
 
@@ -212,7 +213,7 @@ contract('RelayClient', function (accounts) {
         transaction2.sign(perpetrator_priv_key)
         let rawTx = "0x" + transaction2.serialize().toString('hex')
 
-        let tbk = new RelayClient(web3, {relayUrl: localhostOne});
+        let tbk = new RelayClient(web3, { relayUrl: localhostOne });
         await tbk.auditTransaction(rawTx, [localhostOne]);
         // let the auditor do the job
         // testutils.sleep(10)
@@ -224,4 +225,82 @@ contract('RelayClient', function (accounts) {
         // TODO: validate reward distributed fairly
 
     });
+
+    function timeout(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+    it("should fallback to other relays if the preferred one does not respond correctly", async function () {
+        let rc = new RelayClient(web3)
+        let orig_httpSend = rc.httpSend
+        let httpSend = {
+            send: function (url, jsonRequestData, callback) {
+                if (!url.includes("relay")) {
+                    orig_httpSend(url, jsonRequestData, callback)
+                    return
+                }
+                if (counter == 0) {
+                    counter++
+                    setTimeout(callback(new Error("Test error"), null), 100)
+                }
+                else if (counter == 1) {
+                    counter++
+                    setTimeout(callback(null, JSON.stringify({})), 100)
+                }
+                else {
+                    let callback_wrap = function (e, r) {
+                        assert.equal(null, e)
+                        assert.equal(true, r.input.includes(message_hex))
+                        callback(e, r)
+                    }
+                    orig_httpSend.send(url, jsonRequestData, callback_wrap)
+                }
+            }
+        }
+        let mockServerHelper = {
+            getRelaysAdded: async function () {
+                await timeout(200)
+                return filteredRelays
+            },
+            newActiveRelayPinger: function () {
+                return {
+                    nextRelay: async function () {
+                        await timeout(200)
+                        return filteredRelays[counter]
+                    },
+                }
+            },
+            setHub: function(){}
+        }
+        let tbk = new RelayClient(web3, { serverHelper: mockServerHelper });
+        tbk.httpSend = httpSend
+        let filteredRelays = [
+            { relayUrl: "localhost1", RelayServerAddress: accounts[10] },
+            { relayUrl: "localhost2", RelayServerAddress: accounts[10] },
+            { relayUrl: localhostOne, RelayServerAddress: accounts[10] }
+        ]
+
+        var counter = 0
+
+        let message = "hello world"
+        let message_hex = "0b68656c6c6f20776f726c64"
+        let encoded = sr.contract.emitMessage.getData(message)
+
+        let options = {
+            from: gasLess,
+            to: sr.address,
+            txfee: 12,
+            gas_price: 3,
+            gas_limit: 1000000
+        }
+
+        let validTransaction = await tbk.relayTransaction(encoded, options);
+
+        // RelayClient did retry for 2 times
+        assert.equal(2, counter)
+
+        // The transaction was checked by internal logic of RelayClient (tested elsewhere) and deemed valid
+        assert.equal(32, validTransaction.hash(false).length)
+
+    })
 });


### PR DESCRIPTION
In case the relay that responded to '/getaddr' first later fails to
respond to '/relay' request or returns an invalid transaction,
RelayClient will try all available relays first before giving up.

Note that this may require from client to click "Sign" button multiple
times, as relay address is part of hashed message.

Also, refactoring (in process):
1. Scanning blockcahin for Relays is handled by ServerHelper class
2. Pinging the relays to check availability and address - by ActiveRelayPinger
3. HTTP request is moved to HttpWrapper class