### PR TITLE
Allow tests to pass without deterministic mode in Ganache

### DIFF
--- a/contracts/SampleRecipient.sol
+++ b/contracts/SampleRecipient.sol
@@ -38,7 +38,11 @@ contract SampleRecipient is RelayRecipient {
         relays_whitelist[relay] = on;
     }
 
-    address constant blacklisted = 0x3E5e9111Ae8eB78Fe1CC3bb8915d5D461F3Ef9A9;
+    address public blacklisted;
+
+    function set_blacklisted(address addr) public {
+        blacklisted = addr;
+    }
 
     function may_relay(address relay, address from, bytes /* transaction */) public view returns(uint32) {
         // The factory accepts relayed transactions from anyone, so we whitelist our own relays to prevent abuse.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "web3-utils": "^1.0.0-beta.36"
   },
   "scripts": {
-    "test": "make -C server/ && run-with-testrpc -d -a11 'truffle test' ",
+    "test": "make -C server/ && run-with-testrpc 'truffle test' ",
     "lint": "eslint ./src ./test",
     "web": "./restart-relay.sh web"
   },

--- a/test/clientlib.js
+++ b/test/clientlib.js
@@ -247,8 +247,8 @@ contract('RelayClient', function (accounts) {
         let res = await request(localhostOne+'/getaddr')
         let relayServerAddress = JSON.parse(res.body).RelayServerAddress
         let filteredRelays = [
-            { relayUrl: "localhost1", RelayServerAddress: accounts[10] },
-            { relayUrl: "localhost2", RelayServerAddress: accounts[10] },
+            { relayUrl: "localhost1", RelayServerAddress: "0x1" },
+            { relayUrl: "localhost2", RelayServerAddress: "0x2" },
             { relayUrl: localhostOne, RelayServerAddress: relayServerAddress }
         ]
 


### PR DESCRIPTION
1. Add 'set_blacklisted' method to Sample Recepient instead of hardcoded

2. Create 'register_new_relay_with_privkey' to be used for relay
penalize tests. This test requires signing two transactions with the
same nonce, which AFAIK cannot be done with Web3 and requires access to
private key. Therefore, 'register_relay' transaction has to be signed by
this key instead of by Web3 account.